### PR TITLE
switch to new protoc-gen-go, use protoc-gen-go-grpc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ RUN go get -u github.com/coinbase/protoc-gen-rbi
 RUN go get github.com/gomatic/renderizer/v2/cmd/renderizer
 
 # Origin protoc-gen-go should be installed last, for not been overwritten by any other binaries(see #210)
-RUN go get -u github.com/golang/protobuf/protoc-gen-go
+RUN go get google.golang.org/protobuf/cmd/protoc-gen-go
 
 # Need to get these too:
 RUN go get -u github.com/mwitkow/go-proto-validators/@v${go_mwitkow_gpv_version}

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -321,7 +321,8 @@ fi
 GEN_STRING=''
 case $GEN_LANG in
     "go")
-        GEN_STRING="--go_out=${GO_SOURCE_RELATIVE}${GO_MODULE_PREFIX}${GO_PACKAGE_MAP}plugins=grpc:$OUT_DIR"
+        GEN_STRING="--go_out=${GO_SOURCE_RELATIVE}${GO_MODULE_PREFIX}${GO_PACKAGE_MAP}:$OUT_DIR\
+            --go-grpc_out=${GO_SOURCE_RELATIVE}${GO_MODULE_PREFIX}${GO_PACKAGE_MAP}:$OUT_DIR"
         if [[ ${GO_PLUGIN} == "micro" ]]; then
           GEN_STRING="$GEN_STRING --micro_out=$OUT_DIR"
         fi


### PR DESCRIPTION
Google split `protoc-gen-go` into two parts, adding `protoc-gen-go-grpc`, and moving to a new repository. See this comment for a summary:
https://github.com/golang/protobuf/issues/1070#issuecomment-607293496

The all-in-one `protoc-gen-go` has been deprecated, and the new `protoc-gen-go` requires `protoc-gen-go-grpc` when generating gRPC stubs. The container was already installing `protoc-gen-go-grpc` in Dockerfile:71, but (apparently?) not using it because the old `protoc-gen-go` was still being installed on top in Dockerfile:108.

This PR switches to the newer repo for `protoc-gen-go`, and then changes the `protoc` invocation for Go to use `protoc-gen-go-grpc` instead of the deprecated `plugin` option. 

 